### PR TITLE
fixed extensions of images in annotations, from .png to .jpg

### DIFF
--- a/annotations/raccoon-1.xml
+++ b/annotations/raccoon-1.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-1.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-1.png</path>
+	<filename>raccoon-1.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-1.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-10.xml
+++ b/annotations/raccoon-10.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-10.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-10.png</path>
+	<filename>raccoon-10.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-10.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-100.xml
+++ b/annotations/raccoon-100.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-100.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-100.png</path>
+	<filename>raccoon-100.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-100.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-101.xml
+++ b/annotations/raccoon-101.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-101.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-101.png</path>
+	<filename>raccoon-101.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-101.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-102.xml
+++ b/annotations/raccoon-102.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-102.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-102.png</path>
+	<filename>raccoon-102.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-102.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-103.xml
+++ b/annotations/raccoon-103.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-103.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-103.png</path>
+	<filename>raccoon-103.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-103.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-104.xml
+++ b/annotations/raccoon-104.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-104.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-104.png</path>
+	<filename>raccoon-104.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-104.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-105.xml
+++ b/annotations/raccoon-105.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-105.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-105.png</path>
+	<filename>raccoon-105.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-105.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-106.xml
+++ b/annotations/raccoon-106.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-106.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-106.png</path>
+	<filename>raccoon-106.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-106.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-107.xml
+++ b/annotations/raccoon-107.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-107.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-107.png</path>
+	<filename>raccoon-107.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-107.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-108.xml
+++ b/annotations/raccoon-108.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-108.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-108.png</path>
+	<filename>raccoon-108.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-108.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-109.xml
+++ b/annotations/raccoon-109.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-109.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-109.png</path>
+	<filename>raccoon-109.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-109.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-11.xml
+++ b/annotations/raccoon-11.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-11.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-11.png</path>
+	<filename>raccoon-11.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-11.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-110.xml
+++ b/annotations/raccoon-110.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-110.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-110.png</path>
+	<filename>raccoon-110.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-110.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-111.xml
+++ b/annotations/raccoon-111.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-111.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-111.png</path>
+	<filename>raccoon-111.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-111.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-112.xml
+++ b/annotations/raccoon-112.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-112.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-112.png</path>
+	<filename>raccoon-112.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-112.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-113.xml
+++ b/annotations/raccoon-113.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-113.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-113.png</path>
+	<filename>raccoon-113.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-113.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-114.xml
+++ b/annotations/raccoon-114.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-114.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-114.png</path>
+	<filename>raccoon-114.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-114.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-115.xml
+++ b/annotations/raccoon-115.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-115.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-115.png</path>
+	<filename>raccoon-115.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-115.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-116.xml
+++ b/annotations/raccoon-116.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-116.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-116.png</path>
+	<filename>raccoon-116.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-116.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-117.xml
+++ b/annotations/raccoon-117.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-117.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-117.png</path>
+	<filename>raccoon-117.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-117.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-118.xml
+++ b/annotations/raccoon-118.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-118.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-118.png</path>
+	<filename>raccoon-118.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-118.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-119.xml
+++ b/annotations/raccoon-119.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-119.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-119.png</path>
+	<filename>raccoon-119.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-119.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-12.xml
+++ b/annotations/raccoon-12.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-12.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-12.png</path>
+	<filename>raccoon-12.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-12.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-120.xml
+++ b/annotations/raccoon-120.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-120.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-120.png</path>
+	<filename>raccoon-120.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-120.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-121.xml
+++ b/annotations/raccoon-121.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-121.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-121.png</path>
+	<filename>raccoon-121.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-121.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-122.xml
+++ b/annotations/raccoon-122.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-122.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-122.png</path>
+	<filename>raccoon-122.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-122.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-123.xml
+++ b/annotations/raccoon-123.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-123.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-123.png</path>
+	<filename>raccoon-123.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-123.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-124.xml
+++ b/annotations/raccoon-124.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-124.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-124.png</path>
+	<filename>raccoon-124.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-124.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-125.xml
+++ b/annotations/raccoon-125.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-125.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-125.png</path>
+	<filename>raccoon-125.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-125.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-126.xml
+++ b/annotations/raccoon-126.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-126.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-126.png</path>
+	<filename>raccoon-126.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-126.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-127.xml
+++ b/annotations/raccoon-127.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-127.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-127.png</path>
+	<filename>raccoon-127.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-127.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-128.xml
+++ b/annotations/raccoon-128.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-128.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-128.png</path>
+	<filename>raccoon-128.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-128.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-129.xml
+++ b/annotations/raccoon-129.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-129.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-129.png</path>
+	<filename>raccoon-129.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-129.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-13.xml
+++ b/annotations/raccoon-13.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-13.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-13.png</path>
+	<filename>raccoon-13.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-13.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-130.xml
+++ b/annotations/raccoon-130.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-130.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-130.png</path>
+	<filename>raccoon-130.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-130.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-131.xml
+++ b/annotations/raccoon-131.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-131.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-131.png</path>
+	<filename>raccoon-131.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-131.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-132.xml
+++ b/annotations/raccoon-132.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-132.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-132.png</path>
+	<filename>raccoon-132.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-132.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-133.xml
+++ b/annotations/raccoon-133.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-133.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-133.png</path>
+	<filename>raccoon-133.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-133.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-134.xml
+++ b/annotations/raccoon-134.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-134.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-134.png</path>
+	<filename>raccoon-134.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-134.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-135.xml
+++ b/annotations/raccoon-135.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-135.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-135.png</path>
+	<filename>raccoon-135.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-135.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-136.xml
+++ b/annotations/raccoon-136.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-136.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-136.png</path>
+	<filename>raccoon-136.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-136.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-137.xml
+++ b/annotations/raccoon-137.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-137.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-137.png</path>
+	<filename>raccoon-137.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-137.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-138.xml
+++ b/annotations/raccoon-138.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-138.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-138.png</path>
+	<filename>raccoon-138.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-138.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-139.xml
+++ b/annotations/raccoon-139.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-139.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-139.png</path>
+	<filename>raccoon-139.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-139.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-14.xml
+++ b/annotations/raccoon-14.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-14.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-14.png</path>
+	<filename>raccoon-14.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-14.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-140.xml
+++ b/annotations/raccoon-140.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-140.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-140.png</path>
+	<filename>raccoon-140.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-140.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-141.xml
+++ b/annotations/raccoon-141.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-141.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-141.png</path>
+	<filename>raccoon-141.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-141.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-142.xml
+++ b/annotations/raccoon-142.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-142.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-142.png</path>
+	<filename>raccoon-142.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-142.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-143.xml
+++ b/annotations/raccoon-143.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-143.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-143.png</path>
+	<filename>raccoon-143.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-143.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-144.xml
+++ b/annotations/raccoon-144.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-144.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-144.png</path>
+	<filename>raccoon-144.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-144.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-145.xml
+++ b/annotations/raccoon-145.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-145.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-145.png</path>
+	<filename>raccoon-145.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-145.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-146.xml
+++ b/annotations/raccoon-146.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-146.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-146.png</path>
+	<filename>raccoon-146.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-146.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-147.xml
+++ b/annotations/raccoon-147.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-147.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-147.png</path>
+	<filename>raccoon-147.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-147.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-148.xml
+++ b/annotations/raccoon-148.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-148.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-148.png</path>
+	<filename>raccoon-148.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-148.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-149.xml
+++ b/annotations/raccoon-149.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-149.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-149.png</path>
+	<filename>raccoon-149.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-149.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-15.xml
+++ b/annotations/raccoon-15.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-15.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-15.png</path>
+	<filename>raccoon-15.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-15.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-150.xml
+++ b/annotations/raccoon-150.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-150.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-150.png</path>
+	<filename>raccoon-150.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-150.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-151.xml
+++ b/annotations/raccoon-151.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-151.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-151.png</path>
+	<filename>raccoon-151.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-151.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-152.xml
+++ b/annotations/raccoon-152.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-152.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-152.png</path>
+	<filename>raccoon-152.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-152.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-153.xml
+++ b/annotations/raccoon-153.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-153.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-153.png</path>
+	<filename>raccoon-153.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-153.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-154.xml
+++ b/annotations/raccoon-154.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-154.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-154.png</path>
+	<filename>raccoon-154.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-154.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-155.xml
+++ b/annotations/raccoon-155.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-155.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-155.png</path>
+	<filename>raccoon-155.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-155.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-156.xml
+++ b/annotations/raccoon-156.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-156.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-156.png</path>
+	<filename>raccoon-156.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-156.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-157.xml
+++ b/annotations/raccoon-157.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-157.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-157.png</path>
+	<filename>raccoon-157.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-157.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-158.xml
+++ b/annotations/raccoon-158.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-158.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-158.png</path>
+	<filename>raccoon-158.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-158.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-159.xml
+++ b/annotations/raccoon-159.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-159.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-159.png</path>
+	<filename>raccoon-159.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-159.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-16.xml
+++ b/annotations/raccoon-16.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-16.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-16.png</path>
+	<filename>raccoon-16.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-16.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-160.xml
+++ b/annotations/raccoon-160.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-160.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-160.png</path>
+	<filename>raccoon-160.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-160.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-161.xml
+++ b/annotations/raccoon-161.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-161.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-161.png</path>
+	<filename>raccoon-161.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-161.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-162.xml
+++ b/annotations/raccoon-162.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-162.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-162.png</path>
+	<filename>raccoon-162.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-162.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-163.xml
+++ b/annotations/raccoon-163.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-163.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-163.png</path>
+	<filename>raccoon-163.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-163.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-164.xml
+++ b/annotations/raccoon-164.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-164.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-164.png</path>
+	<filename>raccoon-164.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-164.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-165.xml
+++ b/annotations/raccoon-165.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-165.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-165.png</path>
+	<filename>raccoon-165.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-165.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-166.xml
+++ b/annotations/raccoon-166.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-166.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-166.png</path>
+	<filename>raccoon-166.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-166.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-167.xml
+++ b/annotations/raccoon-167.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-167.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-167.png</path>
+	<filename>raccoon-167.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-167.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-168.xml
+++ b/annotations/raccoon-168.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-168.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-168.png</path>
+	<filename>raccoon-168.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-168.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-169.xml
+++ b/annotations/raccoon-169.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-169.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-169.png</path>
+	<filename>raccoon-169.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-169.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-17.xml
+++ b/annotations/raccoon-17.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-17.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-17.png</path>
+	<filename>raccoon-17.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-17.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-170.xml
+++ b/annotations/raccoon-170.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-170.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-170.png</path>
+	<filename>raccoon-170.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-170.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-171.xml
+++ b/annotations/raccoon-171.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-171.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-171.png</path>
+	<filename>raccoon-171.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-171.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-172.xml
+++ b/annotations/raccoon-172.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-172.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-172.png</path>
+	<filename>raccoon-172.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-172.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-173.xml
+++ b/annotations/raccoon-173.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-173.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-173.png</path>
+	<filename>raccoon-173.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-173.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-174.xml
+++ b/annotations/raccoon-174.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-174.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-174.png</path>
+	<filename>raccoon-174.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-174.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-175.xml
+++ b/annotations/raccoon-175.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-175.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-175.png</path>
+	<filename>raccoon-175.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-175.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-176.xml
+++ b/annotations/raccoon-176.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-176.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-176.png</path>
+	<filename>raccoon-176.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-176.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-177.xml
+++ b/annotations/raccoon-177.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-177.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-177.png</path>
+	<filename>raccoon-177.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-177.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-178.xml
+++ b/annotations/raccoon-178.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-178.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-178.png</path>
+	<filename>raccoon-178.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-178.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-179.xml
+++ b/annotations/raccoon-179.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-179.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-179.png</path>
+	<filename>raccoon-179.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-179.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-18.xml
+++ b/annotations/raccoon-18.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-18.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-18.png</path>
+	<filename>raccoon-18.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-18.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-180.xml
+++ b/annotations/raccoon-180.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-180.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-180.png</path>
+	<filename>raccoon-180.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-180.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-181.xml
+++ b/annotations/raccoon-181.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-181.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-181.png</path>
+	<filename>raccoon-181.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-181.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-182.xml
+++ b/annotations/raccoon-182.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-182.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-182.png</path>
+	<filename>raccoon-182.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-182.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-183.xml
+++ b/annotations/raccoon-183.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-183.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-183.png</path>
+	<filename>raccoon-183.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-183.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-184.xml
+++ b/annotations/raccoon-184.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-184.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-184.png</path>
+	<filename>raccoon-184.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-184.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-185.xml
+++ b/annotations/raccoon-185.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-185.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-185.png</path>
+	<filename>raccoon-185.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-185.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-186.xml
+++ b/annotations/raccoon-186.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-186.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-186.png</path>
+	<filename>raccoon-186.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-186.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-187.xml
+++ b/annotations/raccoon-187.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-187.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-187.png</path>
+	<filename>raccoon-187.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-187.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-188.xml
+++ b/annotations/raccoon-188.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-188.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-188.png</path>
+	<filename>raccoon-188.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-188.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-189.xml
+++ b/annotations/raccoon-189.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-189.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-189.png</path>
+	<filename>raccoon-189.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-189.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-19.xml
+++ b/annotations/raccoon-19.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-19.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-19.png</path>
+	<filename>raccoon-19.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-19.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-190.xml
+++ b/annotations/raccoon-190.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-190.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-190.png</path>
+	<filename>raccoon-190.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-190.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-191.xml
+++ b/annotations/raccoon-191.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-191.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-191.png</path>
+	<filename>raccoon-191.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-191.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-192.xml
+++ b/annotations/raccoon-192.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-192.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-192.png</path>
+	<filename>raccoon-192.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-192.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-193.xml
+++ b/annotations/raccoon-193.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-193.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-193.png</path>
+	<filename>raccoon-193.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-193.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-194.xml
+++ b/annotations/raccoon-194.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-194.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-194.png</path>
+	<filename>raccoon-194.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-194.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-195.xml
+++ b/annotations/raccoon-195.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-195.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-195.png</path>
+	<filename>raccoon-195.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-195.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-196.xml
+++ b/annotations/raccoon-196.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-196.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-196.png</path>
+	<filename>raccoon-196.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-196.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-197.xml
+++ b/annotations/raccoon-197.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-197.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-197.png</path>
+	<filename>raccoon-197.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-197.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-198.xml
+++ b/annotations/raccoon-198.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-198.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-198.png</path>
+	<filename>raccoon-198.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-198.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-199.xml
+++ b/annotations/raccoon-199.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-199.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-199.png</path>
+	<filename>raccoon-199.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-199.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-2.xml
+++ b/annotations/raccoon-2.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-2.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-2.png</path>
+	<filename>raccoon-2.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-2.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-20.xml
+++ b/annotations/raccoon-20.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-20.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-20.png</path>
+	<filename>raccoon-20.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-20.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-200.xml
+++ b/annotations/raccoon-200.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-200.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-200.png</path>
+	<filename>raccoon-200.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-200.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-21.xml
+++ b/annotations/raccoon-21.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-21.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-21.png</path>
+	<filename>raccoon-21.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-21.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-22.xml
+++ b/annotations/raccoon-22.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-22.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-22.png</path>
+	<filename>raccoon-22.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-22.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-23.xml
+++ b/annotations/raccoon-23.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-23.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-23.png</path>
+	<filename>raccoon-23.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-23.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-24.xml
+++ b/annotations/raccoon-24.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-24.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-24.png</path>
+	<filename>raccoon-24.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-24.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-25.xml
+++ b/annotations/raccoon-25.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-25.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-25.png</path>
+	<filename>raccoon-25.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-25.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-26.xml
+++ b/annotations/raccoon-26.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-26.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-26.png</path>
+	<filename>raccoon-26.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-26.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-27.xml
+++ b/annotations/raccoon-27.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-27.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-27.png</path>
+	<filename>raccoon-27.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-27.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-28.xml
+++ b/annotations/raccoon-28.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-28.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-28.png</path>
+	<filename>raccoon-28.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-28.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-29.xml
+++ b/annotations/raccoon-29.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-29.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-29.png</path>
+	<filename>raccoon-29.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-29.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-3.xml
+++ b/annotations/raccoon-3.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-3.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-3.png</path>
+	<filename>raccoon-3.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-3.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-30.xml
+++ b/annotations/raccoon-30.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-30.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-30.png</path>
+	<filename>raccoon-30.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-30.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-31.xml
+++ b/annotations/raccoon-31.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-31.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-31.png</path>
+	<filename>raccoon-31.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-31.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-32.xml
+++ b/annotations/raccoon-32.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-32.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-32.png</path>
+	<filename>raccoon-32.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-32.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-33.xml
+++ b/annotations/raccoon-33.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-33.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-33.png</path>
+	<filename>raccoon-33.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-33.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-34.xml
+++ b/annotations/raccoon-34.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-34.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-34.png</path>
+	<filename>raccoon-34.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-34.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-35.xml
+++ b/annotations/raccoon-35.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-35.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-35.png</path>
+	<filename>raccoon-35.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-35.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-36.xml
+++ b/annotations/raccoon-36.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-36.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-36.png</path>
+	<filename>raccoon-36.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-36.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-37.xml
+++ b/annotations/raccoon-37.xml
@@ -1,7 +1,7 @@
 <annotation verified="no">
 	<folder>images</folder>
-	<filename>raccoon-37.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-37.png</path>
+	<filename>raccoon-37.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-37.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-38.xml
+++ b/annotations/raccoon-38.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-38.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-38.png</path>
+	<filename>raccoon-38.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-38.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-39.xml
+++ b/annotations/raccoon-39.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-39.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-39.png</path>
+	<filename>raccoon-39.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-39.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-4.xml
+++ b/annotations/raccoon-4.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-4.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-4.png</path>
+	<filename>raccoon-4.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-4.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-40.xml
+++ b/annotations/raccoon-40.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-40.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-40.png</path>
+	<filename>raccoon-40.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-40.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-41.xml
+++ b/annotations/raccoon-41.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-41.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-41.png</path>
+	<filename>raccoon-41.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-41.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-42.xml
+++ b/annotations/raccoon-42.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-42.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-42.png</path>
+	<filename>raccoon-42.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-42.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-43.xml
+++ b/annotations/raccoon-43.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-43.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-43.png</path>
+	<filename>raccoon-43.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-43.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-44.xml
+++ b/annotations/raccoon-44.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-44.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-44.png</path>
+	<filename>raccoon-44.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-44.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-45.xml
+++ b/annotations/raccoon-45.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-45.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-45.png</path>
+	<filename>raccoon-45.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-45.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-46.xml
+++ b/annotations/raccoon-46.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-46.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-46.png</path>
+	<filename>raccoon-46.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-46.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-47.xml
+++ b/annotations/raccoon-47.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-47.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-47.png</path>
+	<filename>raccoon-47.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-47.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-48.xml
+++ b/annotations/raccoon-48.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-48.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-48.png</path>
+	<filename>raccoon-48.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-48.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-49.xml
+++ b/annotations/raccoon-49.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-49.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-49.png</path>
+	<filename>raccoon-49.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-49.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-5.xml
+++ b/annotations/raccoon-5.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-5.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-5.png</path>
+	<filename>raccoon-5.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-5.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-50.xml
+++ b/annotations/raccoon-50.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-50.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-50.png</path>
+	<filename>raccoon-50.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-50.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-51.xml
+++ b/annotations/raccoon-51.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-51.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-51.png</path>
+	<filename>raccoon-51.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-51.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-52.xml
+++ b/annotations/raccoon-52.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-52.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-52.png</path>
+	<filename>raccoon-52.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-52.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-53.xml
+++ b/annotations/raccoon-53.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-53.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-53.png</path>
+	<filename>raccoon-53.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-53.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-54.xml
+++ b/annotations/raccoon-54.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-54.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-54.png</path>
+	<filename>raccoon-54.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-54.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-55.xml
+++ b/annotations/raccoon-55.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-55.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-55.png</path>
+	<filename>raccoon-55.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-55.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-56.xml
+++ b/annotations/raccoon-56.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-56.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-56.png</path>
+	<filename>raccoon-56.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-56.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-57.xml
+++ b/annotations/raccoon-57.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-57.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-57.png</path>
+	<filename>raccoon-57.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-57.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-58.xml
+++ b/annotations/raccoon-58.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-58.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-58.png</path>
+	<filename>raccoon-58.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-58.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-59.xml
+++ b/annotations/raccoon-59.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-59.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-59.png</path>
+	<filename>raccoon-59.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-59.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-6.xml
+++ b/annotations/raccoon-6.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-6.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-6.png</path>
+	<filename>raccoon-6.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-6.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-60.xml
+++ b/annotations/raccoon-60.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-60.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-60.png</path>
+	<filename>raccoon-60.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-60.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-61.xml
+++ b/annotations/raccoon-61.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-61.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-61.png</path>
+	<filename>raccoon-61.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-61.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-62.xml
+++ b/annotations/raccoon-62.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-62.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-62.png</path>
+	<filename>raccoon-62.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-62.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-63.xml
+++ b/annotations/raccoon-63.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-63.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-63.png</path>
+	<filename>raccoon-63.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-63.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-64.xml
+++ b/annotations/raccoon-64.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-64.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-64.png</path>
+	<filename>raccoon-64.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-64.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-65.xml
+++ b/annotations/raccoon-65.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-65.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-65.png</path>
+	<filename>raccoon-65.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-65.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-66.xml
+++ b/annotations/raccoon-66.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-66.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-66.png</path>
+	<filename>raccoon-66.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-66.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-67.xml
+++ b/annotations/raccoon-67.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-67.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-67.png</path>
+	<filename>raccoon-67.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-67.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-68.xml
+++ b/annotations/raccoon-68.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-68.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-68.png</path>
+	<filename>raccoon-68.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-68.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-69.xml
+++ b/annotations/raccoon-69.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-69.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-69.png</path>
+	<filename>raccoon-69.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-69.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-7.xml
+++ b/annotations/raccoon-7.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-7.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-7.png</path>
+	<filename>raccoon-7.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-7.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-70.xml
+++ b/annotations/raccoon-70.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-70.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-70.png</path>
+	<filename>raccoon-70.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-70.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-71.xml
+++ b/annotations/raccoon-71.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-71.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-71.png</path>
+	<filename>raccoon-71.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-71.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-72.xml
+++ b/annotations/raccoon-72.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-72.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-72.png</path>
+	<filename>raccoon-72.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-72.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-73.xml
+++ b/annotations/raccoon-73.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-73.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-73.png</path>
+	<filename>raccoon-73.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-73.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-74.xml
+++ b/annotations/raccoon-74.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-74.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-74.png</path>
+	<filename>raccoon-74.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-74.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-75.xml
+++ b/annotations/raccoon-75.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-75.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-75.png</path>
+	<filename>raccoon-75.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-75.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-76.xml
+++ b/annotations/raccoon-76.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-76.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-76.png</path>
+	<filename>raccoon-76.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-76.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-77.xml
+++ b/annotations/raccoon-77.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-77.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-77.png</path>
+	<filename>raccoon-77.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-77.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-78.xml
+++ b/annotations/raccoon-78.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-78.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-78.png</path>
+	<filename>raccoon-78.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-78.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-79.xml
+++ b/annotations/raccoon-79.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-79.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-79.png</path>
+	<filename>raccoon-79.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-79.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-8.xml
+++ b/annotations/raccoon-8.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-8.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-8.png</path>
+	<filename>raccoon-8.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-8.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-80.xml
+++ b/annotations/raccoon-80.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-80.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-80.png</path>
+	<filename>raccoon-80.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-80.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-81.xml
+++ b/annotations/raccoon-81.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-81.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-81.png</path>
+	<filename>raccoon-81.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-81.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-82.xml
+++ b/annotations/raccoon-82.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-82.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-82.png</path>
+	<filename>raccoon-82.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-82.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-83.xml
+++ b/annotations/raccoon-83.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-83.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-83.png</path>
+	<filename>raccoon-83.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-83.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-84.xml
+++ b/annotations/raccoon-84.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-84.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-84.png</path>
+	<filename>raccoon-84.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-84.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-85.xml
+++ b/annotations/raccoon-85.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-85.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-85.png</path>
+	<filename>raccoon-85.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-85.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-86.xml
+++ b/annotations/raccoon-86.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-86.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-86.png</path>
+	<filename>raccoon-86.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-86.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-87.xml
+++ b/annotations/raccoon-87.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-87.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-87.png</path>
+	<filename>raccoon-87.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-87.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-88.xml
+++ b/annotations/raccoon-88.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-88.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-88.png</path>
+	<filename>raccoon-88.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-88.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-89.xml
+++ b/annotations/raccoon-89.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-89.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-89.png</path>
+	<filename>raccoon-89.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-89.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-9.xml
+++ b/annotations/raccoon-9.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-9.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-9.png</path>
+	<filename>raccoon-9.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-9.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-90.xml
+++ b/annotations/raccoon-90.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-90.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-90.png</path>
+	<filename>raccoon-90.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-90.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-91.xml
+++ b/annotations/raccoon-91.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-91.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-91.png</path>
+	<filename>raccoon-91.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-91.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-92.xml
+++ b/annotations/raccoon-92.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-92.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-92.png</path>
+	<filename>raccoon-92.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-92.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-93.xml
+++ b/annotations/raccoon-93.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-93.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-93.png</path>
+	<filename>raccoon-93.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-93.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-94.xml
+++ b/annotations/raccoon-94.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-94.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-94.png</path>
+	<filename>raccoon-94.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-94.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-95.xml
+++ b/annotations/raccoon-95.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-95.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-95.png</path>
+	<filename>raccoon-95.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-95.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-96.xml
+++ b/annotations/raccoon-96.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-96.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-96.png</path>
+	<filename>raccoon-96.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-96.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-97.xml
+++ b/annotations/raccoon-97.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-97.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-97.png</path>
+	<filename>raccoon-97.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-97.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-98.xml
+++ b/annotations/raccoon-98.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-98.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-98.png</path>
+	<filename>raccoon-98.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-98.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>

--- a/annotations/raccoon-99.xml
+++ b/annotations/raccoon-99.xml
@@ -1,7 +1,7 @@
 <annotation verified="yes">
 	<folder>images</folder>
-	<filename>raccoon-99.png</filename>
-	<path>/Users/datitran/Desktop/raccoon/images/raccoon-99.png</path>
+	<filename>raccoon-99.jpg</filename>
+	<path>/Users/datitran/Desktop/raccoon/images/raccoon-99.jpg</path>
 	<source>
 		<database>Unknown</database>
 	</source>


### PR DESCRIPTION
I discover that you are not naming the images in the annotations correctly. The image extension is .jpg but is named .png in the annotations.